### PR TITLE
Исправляет ошибку на новой версии CMS

### DIFF
--- a/storage.php
+++ b/storage.php
@@ -6,7 +6,7 @@
  */
 
 // начало шаблона
-require(getinfo('template_dir') . 'main-start.php');
+if ($fn = mso_find_ts_file('main/main-start.php')) require($fn);
 
 // загружаем опции
 $options = mso_get_option('plugin_dignity_storage', 'plugins', array());
@@ -170,6 +170,6 @@ else
 
 echo $out;
 
-require(getinfo('template_dir') . 'main-end.php');
+if ($fn = mso_find_ts_file('main/main-end.php')) require($fn);
 
 # end of file


### PR DESCRIPTION
Message: require(main-start.php) [function.require]: failed to open stream: No such file or directory